### PR TITLE
fix(streamlit): Corrects button key and prevents KeyError

### DIFF
--- a/components/ui_components.py
+++ b/components/ui_components.py
@@ -81,8 +81,9 @@ def disegna_sezione_attivita(lista_attivita, section_key, ruolo_utente):
                         st.markdown(f"**PdL `{report['pdl']}`** - Inviato il {pd.to_datetime(report['data_compilazione']).strftime('%d/%m/%Y %H:%M')}")
                         st.caption("Report Inviato:")
                         st.info(report['testo_report'])
-                        if st.button("Modifica Report", key=f"edit_report_{report['id_report']}"):
+                        if st.button("Modifica Report", key=f"edit_report_{section_key}_{report['id_report']}"):
                             task_data = report.to_dict()
+                            task_data['section_key'] = section_key
                             st.session_state.debriefing_task = task_data
                             st.session_state.report_mode = 'manual'
                             st.rerun()


### PR DESCRIPTION
The 'Modifica Report' button was causing a `StreamlitDuplicateElementKey` error because its key was not unique across different tabs. This was fixed by adding the `section_key` to the button's key.

Additionally, a `KeyError: 'section_key'` would occur because the `task_data` dictionary was missing this key when saved to the session state. This was resolved by adding the `section_key` to the dictionary before saving.

feat(email): Implements conditional email sending logic

This commit introduces a new email sending function with two distinct behaviors:
1.  **PDF Export:** Creates a draft in Outlook with 'ciro.scaravelli@coemi.it' as the recipient and 'francesco.millo@coemi.it' in CC.
2.  **Direct Send:** Sends emails directly to 'francesco.millo@coemi.it' and 'gianky.allegretti@gmail.com' for all other use cases.

The function also removes a specific signature from the email body before sending or creating a draft.